### PR TITLE
Fix: Include API key in MCP test query headers

### DIFF
--- a/amm_gui/components/mcp_server_manager.py
+++ b/amm_gui/components/mcp_server_manager.py
@@ -460,6 +460,13 @@ def mcp_server_manager():
                         with st.spinner("Processing query..."):
                             try:
                                 import requests
+                                
+                                # Get server details for API key
+                                server_details = st.session_state.mcp_servers.get(server['id'])
+                                headers = {}
+                                if server_details and server_details.get("api_key_required") and server_details.get("api_key"):
+                                    headers = {"X-API-Key": server_details["api_key"]}
+                                
                                 response = requests.post(
                                     f"{server['url']}/generate",
                                     json={
@@ -467,6 +474,7 @@ def mcp_server_manager():
                                         "parameters": {},
                                         "context": {}
                                     },
+                                    headers=headers,
                                     timeout=30
                                 )
                                 


### PR DESCRIPTION
The GUI's MCP server test query functionality was failing with a 401 error when the target server was configured to require an API key. This was because the test query was not sending the API key.

This commit modifies `amm_gui/components/mcp_server_manager.py` to include the `X-API-Key` header in the `/generate` request if the server instance was launched with API key authentication enabled. The API key is retrieved from the server's stored information in `st.session_state.mcp_servers`.

Manual testing will be performed by you after this commit is pushed.